### PR TITLE
Refactor how proposal votes are fetched

### DIFF
--- a/interfaces/proposal.ts
+++ b/interfaces/proposal.ts
@@ -1,3 +1,7 @@
+export interface IUserVote { vote_option: string; user_weight: string }
+
+export interface IVotes { [key: string]: IUserVote}
+
 export interface IProposal {
 	id: number
 	proposal: {
@@ -10,13 +14,11 @@ export interface IProposal {
 			}
 		}
 		status: string | any
-		total_vote_counts: number
+		total_vote_counts: string
 		vote_counts: {
 			[key: string]: string
 		}
-		votes: {
-			[key: string]: { vote_option: string; user_weight: number }
-		}
+		votes: IVotes,
 		submission_time: number
 		proposal_start_time: number
 		proposal_period: number

--- a/pages/proposal.tsx
+++ b/pages/proposal.tsx
@@ -15,7 +15,7 @@ const Proposal = () => {
 
 	useEffect(() => {
 		const getProposals = async () => {
-			let proposalDetail = await near.nearViewFunction({
+			const proposalDetail = await near.nearViewFunction({
 				contractName: CONTRACT.DAO,
 				methodName: 'get_proposals',
 				args: {
@@ -25,33 +25,21 @@ const Proposal = () => {
 			})
 
 			for (const [i, proposal] of proposalDetail.entries()) {
-				const proposalVotes = await near.nearViewFunction({
-					contractName: CONTRACT.DAO,
-					methodName: 'get_proposal_votes',
-					args: {
-						id: proposal.id,
-						from_index: 0,
-						limit: 10,
-					}
-				})
-	
-				const proposalVoteUser = await near.nearViewFunction({
-					contractName: CONTRACT.DAO,
-					methodName: 'get_proposal_vote',
-					args: {
-						id: proposal.id,
-						account_id: accountId
-					}
-				})
-	
 				const proposalVotesWrap: IVotes = {}
 	
-				proposalVotes.forEach((accountId: string, userVote: IUserVote) => {
-					proposalVotesWrap[accountId] = userVote
-				})
-	
-				if (proposalVoteUser) proposalVotesWrap[accountId as string] = proposalVoteUser
+				if (accountId) {
+					const proposalVoteUser = await near.nearViewFunction({
+						contractName: CONTRACT.DAO,
+						methodName: 'get_proposal_vote',
+						args: {
+							id: proposal.id,
+							account_id: accountId
+						}
+					})
 
+					if (proposalVoteUser) proposalVotesWrap[accountId as string] = proposalVoteUser
+				}
+	
 				proposalDetail[i].proposal.votes = proposalVotesWrap
 			}
 

--- a/pages/proposal/[id].tsx
+++ b/pages/proposal/[id].tsx
@@ -37,7 +37,7 @@ const ProposalItemDetail = () => {
 				},
 			})
 
-			const proposalVotes = await near.nearViewFunction({
+			const proposalVotes: [string, IUserVote][] = await near.nearViewFunction({
 				contractName: CONTRACT.DAO,
 				methodName: 'get_proposal_votes',
 				args: {
@@ -47,23 +47,24 @@ const ProposalItemDetail = () => {
 				}
 			})
 
-			const proposalVoteUser = await near.nearViewFunction({
-				contractName: CONTRACT.DAO,
-				methodName: 'get_proposal_vote',
-				args: {
-					id: parseInt(router.query.id as string),
-					account_id: accountId
-				}
-			})
-
 			const proposalVotesWrap: IVotes = {}
 
-			proposalVotes.forEach((userVoteTuple: Array<any>) => {
+			proposalVotes.forEach((userVoteTuple) => {
 				proposalVotesWrap[userVoteTuple[0]] = userVoteTuple[1]
 			})
 
-			if (proposalVoteUser) proposalVotesWrap[accountId as string] = proposalVoteUser
+			if (accountId) {
+				const proposalVoteUser = await near.nearViewFunction({
+					contractName: CONTRACT.DAO,
+					methodName: 'get_proposal_vote',
+					args: {
+						id: parseInt(router.query.id as string),
+						account_id: accountId
+					}
+				})
 
+				if (proposalVoteUser) proposalVotesWrap[accountId as string] = proposalVoteUser
+			}
 
 			proposalDetail.proposal.votes = proposalVotesWrap
 

--- a/pages/proposal/[id].tsx
+++ b/pages/proposal/[id].tsx
@@ -6,7 +6,7 @@ import VotesPeople from 'components/Proposal/VotesPeople'
 import VotingPower from 'components/Proposal/VotingPower'
 import dayjs from 'dayjs'
 import { useNearProvider } from 'hooks/useNearProvider'
-import { IProposal } from 'interfaces/proposal'
+import { IProposal, IUserVote, IVotes } from 'interfaces/proposal'
 import { useRouter } from 'next/dist/client/router'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
@@ -36,6 +36,36 @@ const ProposalItemDetail = () => {
 					id: parseInt(router.query.id as string),
 				},
 			})
+
+			const proposalVotes = await near.nearViewFunction({
+				contractName: CONTRACT.DAO,
+				methodName: 'get_proposal_votes',
+				args: {
+					id: parseInt(router.query.id as string),
+					from_index: 0,
+					limit: 10,
+				}
+			})
+
+			const proposalVoteUser = await near.nearViewFunction({
+				contractName: CONTRACT.DAO,
+				methodName: 'get_proposal_vote',
+				args: {
+					id: parseInt(router.query.id as string),
+					account_id: accountId
+				}
+			})
+
+			const proposalVotesWrap: IVotes = {}
+
+			proposalVotes.forEach((userVoteTuple: Array<any>) => {
+				proposalVotesWrap[userVoteTuple[0]] = userVoteTuple[1]
+			})
+
+			if (proposalVoteUser) proposalVotesWrap[accountId as string] = proposalVoteUser
+
+
+			proposalDetail.proposal.votes = proposalVotesWrap
 
 			setProposal(proposalDetail)
 		}


### PR DESCRIPTION
# Refactor
[-] How proposal votes are fetched is now using skip limit, and we also provide get function for an individual account
[-] Change u128 to U128, which requires the interface to be 'string' instead of 'number'